### PR TITLE
feature/UC8: Product zoekbalk toegevoegd in boodschappenlijst-pagina

### DIFF
--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -23,6 +23,8 @@ namespace Grocery.App.ViewModels
         GroceryList groceryList = new(0, "None", DateOnly.MinValue, "", 0);
         [ObservableProperty]
         string myMessage;
+        [ObservableProperty]
+        string noProductMessage;
 
         public GroceryListItemsViewModel(IGroceryListItemsService groceryListItemsService, IProductService productService, IFileSaverService fileSaverService)
         {
@@ -39,12 +41,20 @@ namespace Grocery.App.ViewModels
             GetAvailableProducts();
         }
 
-        private void GetAvailableProducts()
+        private void GetAvailableProducts(string? productSearch = null)
         {
             AvailableProducts.Clear();
             foreach (Product p in _productService.GetAll())
-                if (MyGroceryListItems.FirstOrDefault(g => g.ProductId == p.Id) == null  && p.Stock > 0)
+                if (MyGroceryListItems.FirstOrDefault(g => g.ProductId == p.Id) == null  && p.Stock > 0 && (productSearch == null || p.Name.ToLower().Contains(productSearch.ToLower())))
                     AvailableProducts.Add(p);
+            
+            if (productSearch == null || productSearch == "")
+            {
+                NoProductMessage = "Er zijn geen producten meer om toe te voegen";
+            } else
+            {
+                NoProductMessage = "Er zijn geen beschikbare producten die aan deze zoekopdracht voldoen";
+            }
         }
 
         partial void OnGroceryListChanged(GroceryList value)
@@ -84,6 +94,12 @@ namespace Grocery.App.ViewModels
             {
                 await Toast.Make($"Opslaan mislukt: {ex.Message}").Show(cancellationToken);
             }
+        }
+
+        [RelayCommand]
+        public void SearchProduct(string productName)
+        {
+            GetAvailableProducts(productName);
         }
 
     }

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -54,6 +54,8 @@
 
         <Border Grid.Row="1" Grid.Column="1" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
             <StackLayout>
+                <SearchBar Placeholder="Zoek producten" x:Name="searchBar" SearchCommand="{Binding SearchProductCommand}" SearchCommandParameter="{Binding Text, x:DataType='SearchBar', Source={x:Reference searchBar}}" />
+
                 <CollectionView ItemsSource="{Binding AvailableProducts}" Margin="5" WidthRequest="300" HorizontalOptions="Start"
                     SelectionMode="Single"
                     SelectionChangedCommand="{Binding AddProductCommand}"
@@ -76,7 +78,7 @@
                     <CollectionView.EmptyView>
                         <ContentView>
                             <VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center">
-                                <Label Text="Er zijn geen producten meer om toe te voegen" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
+                                <Label Text="{Binding NoProductMessage}" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
                             </VerticalStackLayout>
                         </ContentView>
                     </CollectionView.EmptyView>


### PR DESCRIPTION
Use Case 8 "Zoeken producten" geïmplementeerd d.m.v. een zoekbalk in de boodschappenlijst-pagina die de beschikbare producten op naam filtert.

Hiervoor zijn de onderstaande veranderingen doorgevoerd:

1. Zoekbalk toegevoegd in `GroceryListItemsView.xaml`
2. Aan `GetAvailableProducts` methode een zoek-string parameter toegevoegd
3. Nieuwe methode SearchProduct aangemaakt in `GroceryListItemsViewModel.cs` die bovenstaande methode aanroept met zoek-string.
4. Nieuwe ObservableProperty `noProductMessage` aangemaakt die tekst voor geen producten aanpast op basis van of er iets is ingevuld in de zoekbalk